### PR TITLE
feat/mongodb repository

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,6 +13,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:7.0.6
+        ports:
+          - 27017:27017
 
     steps:
     - name: Checkout repository

--- a/poetry.lock
+++ b/poetry.lock
@@ -96,6 +96,26 @@ files = [
 toml = ["tomli"]
 
 [[package]]
+name = "dnspython"
+version = "2.6.1"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "dnspython-2.6.1-py3-none-any.whl", hash = "sha256:5ef3b9680161f6fa89daf8ad451b5f1a33b18ae8a1c6778cdf4b43f08c0a6e50"},
+    {file = "dnspython-2.6.1.tar.gz", hash = "sha256:e8f0f9c23a7b7cb99ded64e6c3a6f3e701d78f50c55e002b839dea7225cff7cc"},
+]
+
+[package.extras]
+dev = ["black (>=23.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "mypy (>=1.8)", "pylint (>=3)", "pytest (>=7.4)", "pytest-cov (>=4.1.0)", "sphinx (>=7.2.0)", "twine (>=4.0.0)", "wheel (>=0.42.0)"]
+dnssec = ["cryptography (>=41)"]
+doh = ["h2 (>=4.1.0)", "httpcore (>=1.0.0)", "httpx (>=0.26.0)"]
+doq = ["aioquic (>=0.9.25)"]
+idna = ["idna (>=3.6)"]
+trio = ["trio (>=0.23)"]
+wmi = ["wmi (>=1.5.1)"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -105,6 +125,30 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "motor"
+version = "3.5.1"
+description = "Non-blocking MongoDB driver for Tornado or asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "motor-3.5.1-py3-none-any.whl", hash = "sha256:f95a9ea0f011464235e0bd72910baa291db3a6009e617ac27b82f57885abafb8"},
+    {file = "motor-3.5.1.tar.gz", hash = "sha256:1622bd7b39c3e6375607c14736f6e1d498128eadf6f5f93f8786cf17d37062ac"},
+]
+
+[package.dependencies]
+pymongo = ">=4.5,<5"
+
+[package.extras]
+aws = ["pymongo[aws] (>=4.5,<5)"]
+docs = ["aiohttp", "readthedocs-sphinx-search (>=0.3,<1.0)", "sphinx (>=5.3,<8)", "sphinx-rtd-theme (>=2,<3)", "tornado"]
+encryption = ["pymongo[encryption] (>=4.5,<5)"]
+gssapi = ["pymongo[gssapi] (>=4.5,<5)"]
+ocsp = ["pymongo[ocsp] (>=4.5,<5)"]
+snappy = ["pymongo[snappy] (>=4.5,<5)"]
+test = ["aiohttp (!=3.8.6)", "mockupdb", "pymongo[encryption] (>=4.5,<5)", "pytest (>=7)", "tornado (>=5)"]
+zstd = ["pymongo[zstd] (>=4.5,<5)"]
 
 [[package]]
 name = "mslex"
@@ -170,6 +214,78 @@ files = [
 
 [package.extras]
 test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
+
+[[package]]
+name = "pymongo"
+version = "4.8.0"
+description = "Python driver for MongoDB <http://www.mongodb.org>"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pymongo-4.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f2b7bec27e047e84947fbd41c782f07c54c30c76d14f3b8bf0c89f7413fac67a"},
+    {file = "pymongo-4.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3c68fe128a171493018ca5c8020fc08675be130d012b7ab3efe9e22698c612a1"},
+    {file = "pymongo-4.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:920d4f8f157a71b3cb3f39bc09ce070693d6e9648fb0e30d00e2657d1dca4e49"},
+    {file = "pymongo-4.8.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52b4108ac9469febba18cea50db972605cc43978bedaa9fea413378877560ef8"},
+    {file = "pymongo-4.8.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:180d5eb1dc28b62853e2f88017775c4500b07548ed28c0bd9c005c3d7bc52526"},
+    {file = "pymongo-4.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aec2b9088cdbceb87e6ca9c639d0ff9b9d083594dda5ca5d3c4f6774f4c81b33"},
+    {file = "pymongo-4.8.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d0cf61450feadca81deb1a1489cb1a3ae1e4266efd51adafecec0e503a8dcd84"},
+    {file = "pymongo-4.8.0-cp310-cp310-win32.whl", hash = "sha256:8b18c8324809539c79bd6544d00e0607e98ff833ca21953df001510ca25915d1"},
+    {file = "pymongo-4.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e5df28f74002e37bcbdfdc5109799f670e4dfef0fb527c391ff84f078050e7b5"},
+    {file = "pymongo-4.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6b50040d9767197b77ed420ada29b3bf18a638f9552d80f2da817b7c4a4c9c68"},
+    {file = "pymongo-4.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:417369ce39af2b7c2a9c7152c1ed2393edfd1cbaf2a356ba31eb8bcbd5c98dd7"},
+    {file = "pymongo-4.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf821bd3befb993a6db17229a2c60c1550e957de02a6ff4dd0af9476637b2e4d"},
+    {file = "pymongo-4.8.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9365166aa801c63dff1a3cb96e650be270da06e3464ab106727223123405510f"},
+    {file = "pymongo-4.8.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc8b8582f4209c2459b04b049ac03c72c618e011d3caa5391ff86d1bda0cc486"},
+    {file = "pymongo-4.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16e5019f75f6827bb5354b6fef8dfc9d6c7446894a27346e03134d290eb9e758"},
+    {file = "pymongo-4.8.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3b5802151fc2b51cd45492c80ed22b441d20090fb76d1fd53cd7760b340ff554"},
+    {file = "pymongo-4.8.0-cp311-cp311-win32.whl", hash = "sha256:4bf58e6825b93da63e499d1a58de7de563c31e575908d4e24876234ccb910eba"},
+    {file = "pymongo-4.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:b747c0e257b9d3e6495a018309b9e0c93b7f0d65271d1d62e572747f4ffafc88"},
+    {file = "pymongo-4.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e6a720a3d22b54183352dc65f08cd1547204d263e0651b213a0a2e577e838526"},
+    {file = "pymongo-4.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:31e4d21201bdf15064cf47ce7b74722d3e1aea2597c6785882244a3bb58c7eab"},
+    {file = "pymongo-4.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6b804bb4f2d9dc389cc9e827d579fa327272cdb0629a99bfe5b83cb3e269ebf"},
+    {file = "pymongo-4.8.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f2fbdb87fe5075c8beb17a5c16348a1ea3c8b282a5cb72d173330be2fecf22f5"},
+    {file = "pymongo-4.8.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd39455b7ee70aabee46f7399b32ab38b86b236c069ae559e22be6b46b2bbfc4"},
+    {file = "pymongo-4.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:940d456774b17814bac5ea7fc28188c7a1338d4a233efbb6ba01de957bded2e8"},
+    {file = "pymongo-4.8.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:236bbd7d0aef62e64caf4b24ca200f8c8670d1a6f5ea828c39eccdae423bc2b2"},
+    {file = "pymongo-4.8.0-cp312-cp312-win32.whl", hash = "sha256:47ec8c3f0a7b2212dbc9be08d3bf17bc89abd211901093e3ef3f2adea7de7a69"},
+    {file = "pymongo-4.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:e84bc7707492f06fbc37a9f215374d2977d21b72e10a67f1b31893ec5a140ad8"},
+    {file = "pymongo-4.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:519d1bab2b5e5218c64340b57d555d89c3f6c9d717cecbf826fb9d42415e7750"},
+    {file = "pymongo-4.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:87075a1feb1e602e539bdb1ef8f4324a3427eb0d64208c3182e677d2c0718b6f"},
+    {file = "pymongo-4.8.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f53429515d2b3e86dcc83dadecf7ff881e538c168d575f3688698a8707b80a"},
+    {file = "pymongo-4.8.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fdc20cd1e1141b04696ffcdb7c71e8a4a665db31fe72e51ec706b3bdd2d09f36"},
+    {file = "pymongo-4.8.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:284d0717d1a7707744018b0b6ee7801b1b1ff044c42f7be7a01bb013de639470"},
+    {file = "pymongo-4.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5bf0eb8b6ef40fa22479f09375468c33bebb7fe49d14d9c96c8fd50355188b0"},
+    {file = "pymongo-4.8.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ecd71b9226bd1d49416dc9f999772038e56f415a713be51bf18d8676a0841c8"},
+    {file = "pymongo-4.8.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0061af6e8c5e68b13f1ec9ad5251247726653c5af3c0bbdfbca6cf931e99216"},
+    {file = "pymongo-4.8.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:658d0170f27984e0d89c09fe5c42296613b711a3ffd847eb373b0dbb5b648d5f"},
+    {file = "pymongo-4.8.0-cp38-cp38-win32.whl", hash = "sha256:3ed1c316718a2836f7efc3d75b4b0ffdd47894090bc697de8385acd13c513a70"},
+    {file = "pymongo-4.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:7148419eedfea9ecb940961cfe465efaba90595568a1fb97585fb535ea63fe2b"},
+    {file = "pymongo-4.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e8400587d594761e5136a3423111f499574be5fd53cf0aefa0d0f05b180710b0"},
+    {file = "pymongo-4.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af3e98dd9702b73e4e6fd780f6925352237f5dce8d99405ff1543f3771201704"},
+    {file = "pymongo-4.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de3a860f037bb51f968de320baef85090ff0bbb42ec4f28ec6a5ddf88be61871"},
+    {file = "pymongo-4.8.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0fc18b3a093f3db008c5fea0e980dbd3b743449eee29b5718bc2dc15ab5088bb"},
+    {file = "pymongo-4.8.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18c9d8f975dd7194c37193583fd7d1eb9aea0c21ee58955ecf35362239ff31ac"},
+    {file = "pymongo-4.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:408b2f8fdbeca3c19e4156f28fff1ab11c3efb0407b60687162d49f68075e63c"},
+    {file = "pymongo-4.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6564780cafd6abeea49759fe661792bd5a67e4f51bca62b88faab497ab5fe89"},
+    {file = "pymongo-4.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d18d86bc9e103f4d3d4f18b85a0471c0e13ce5b79194e4a0389a224bb70edd53"},
+    {file = "pymongo-4.8.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:9097c331577cecf8034422956daaba7ec74c26f7b255d718c584faddd7fa2e3c"},
+    {file = "pymongo-4.8.0-cp39-cp39-win32.whl", hash = "sha256:d5428dbcd43d02f6306e1c3c95f692f68b284e6ee5390292242f509004c9e3a8"},
+    {file = "pymongo-4.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:ef7225755ed27bfdb18730c68f6cb023d06c28f2b734597480fb4c0e500feb6f"},
+    {file = "pymongo-4.8.0.tar.gz", hash = "sha256:454f2295875744dc70f1881e4b2eb99cdad008a33574bc8aaf120530f66c0cde"},
+]
+
+[package.dependencies]
+dnspython = ">=1.16.0,<3.0.0"
+
+[package.extras]
+aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
+docs = ["furo (==2023.9.10)", "readthedocs-sphinx-search (>=0.3,<1.0)", "sphinx (>=5.3,<8)", "sphinx-rtd-theme (>=2,<3)", "sphinxcontrib-shellcheck (>=1,<2)"]
+encryption = ["certifi", "pymongo-auth-aws (>=1.1.0,<2.0.0)", "pymongocrypt (>=1.6.0,<2.0.0)"]
+gssapi = ["pykerberos", "winkerberos (>=0.5.0)"]
+ocsp = ["certifi", "cryptography (>=2.5)", "pyopenssl (>=17.2.0)", "requests (<3.0.0)", "service-identity (>=18.1.0)"]
+snappy = ["python-snappy"]
+test = ["pytest (>=7)"]
+zstd = ["zstandard"]
 
 [[package]]
 name = "pytest"
@@ -285,4 +401,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.*"
-content-hash = "5e8d848aeaa64b6faac1f9c0063e3af7740293b34c5f99dc7e857d6ea4315b65"
+content-hash = "65ff9dd32ceaa5b732b1c8145ee50b33d12ca73d07791345d55450a7b5d9bb0f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ pytest-cov = "^5.0.0"
 taskipy = "^1.13.0"
 ruff = "^0.6.5"
 pytest-asyncio = "^0.24.0"
+motor = "^3.5.1"
 
 [tool.ruff]
 line-length = 79
@@ -30,7 +31,6 @@ quote-style = 'single'
 pythonpath = "."
 addopts = '-p no:warnings'
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "session"
 
 [tool.taskipy.tasks]
 lint = 'ruff check .; ruff check . --diff'

--- a/src/adapters/exceptions.py
+++ b/src/adapters/exceptions.py
@@ -1,0 +1,10 @@
+class ExternalError(Exception):
+    pass
+
+
+class DatabaseError(ExternalError):
+    def __init__(self, error: Exception):
+        self.error = error
+
+    def __str__(self) -> str:
+        return str(self.error)

--- a/src/adapters/repositories/auction_repository/mongodb_repository.py
+++ b/src/adapters/repositories/auction_repository/mongodb_repository.py
@@ -1,0 +1,112 @@
+from datetime import date, datetime
+from typing import Any
+from uuid import UUID
+
+from bson import Binary
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from src.adapters.exceptions import DatabaseError
+from src.domain.entities.auction import Auction
+from src.domain.entities.bid import Bid
+from src.domain.entities.item import Item
+from src.domain.value_objects.price import Price
+from src.ports.repositories.auction_repository import AuctionRepository
+
+
+class MongoAuctionRepository(AuctionRepository):
+    def __init__(self, client: AsyncIOMotorClient):  # type: ignore
+        self.collection = client.auctions.auction  # type: ignore
+
+    async def get(self, **filters: Any) -> Auction | None:
+        filters = self.__get_filters(filters)
+        try:
+            document = await self.collection.find_one(filters)
+            return self.__to_auction_entity(document) if document else None
+        except Exception as e:
+            raise DatabaseError(e)
+
+    async def add_bid(self, bid: Bid) -> bool:
+        try:
+            r = await self.collection.update_one(
+                {'_id': Binary.from_uuid(bid.auction_id)},
+                {'$push': {'bids': self.__bid_to_doc(bid)}},
+            )
+            return bool(r.modified_count)
+        except Exception as e:
+            raise DatabaseError(e)
+
+    async def add(self, auction: Auction) -> None:
+        try:
+            auction_doc = self.__auction_to_doc(auction)
+            await self.collection.insert_one(auction_doc)
+        except Exception as e:
+            raise DatabaseError(e)
+
+    @staticmethod
+    def __get_filters(filters_args: dict[str, Any]) -> dict[str, Any]:
+        filters = {}
+        if f := filters_args.get('id'):
+            filters['_id'] = Binary.from_uuid(f)
+        return filters
+
+    def __auction_to_doc(self, auction: Auction) -> dict[str, Any]:
+        return {
+            '_id': Binary.from_uuid(auction.id),
+            'item': {
+                '_id': Binary.from_uuid(auction.item.id),
+                'name': auction.item.name,
+                'description': auction.item.description,
+            },
+            'seller_id': Binary.from_uuid(auction.seller_id),
+            'start_date': auction.start_date.isoformat(),
+            'end_date': auction.end_date.isoformat(),
+            'start_price': {
+                'value': auction.start_price.value,
+                'currency': auction.start_price.currency,
+            },
+            'bids': [self.__bid_to_doc(bid) for bid in auction.bids],
+        }
+
+    @staticmethod
+    def __bid_to_doc(bid: Bid) -> dict[str, Any]:
+        return {
+            'bidder_id': Binary.from_uuid(bid.bidder_id),
+            'price': {
+                'value': bid.price.value,
+                'currency': bid.price.currency,
+            },
+            'auction_id': Binary.from_uuid(bid.auction_id),
+            '_id': Binary.from_uuid(bid.id),
+            'created_at': bid.created_at.isoformat(),
+        }
+
+    def __to_auction_entity(self, obj: dict[str, Any]) -> Auction:
+        return Auction(
+            id=UUID(bytes=obj['_id']),
+            item=Item(
+                id=UUID(bytes=obj['item']['_id']),
+                name=obj['item']['name'],
+                description=obj['item']['description'],
+            ),
+            seller_id=UUID(bytes=obj['seller_id']),
+            start_date=date.fromisoformat(obj['start_date']),
+            end_date=date.fromisoformat(obj['end_date']),
+            start_price=Price(
+                value=obj['start_price']['value'],
+                currency=obj['start_price']['currency'],
+            ),
+            bids=[self.__to_bid_entity(bid) for bid in obj['bids']],
+        )
+
+    @staticmethod
+    def __to_bid_entity(bid: dict[str, Any]) -> Bid:
+        return Bid(
+            bidder_id=UUID(bytes=bid['bidder_id']),
+            price=Price(
+                value=bid['price']['value'],
+                currency=bid['price']['currency'],
+            ),
+            auction_id=UUID(bytes=bid['auction_id']),
+            id=UUID(bytes=bid['_id']),
+            created_at=datetime.fromisoformat(bid['created_at']),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import asyncio
+
+import pytest
+from motor.motor_asyncio import AsyncIOMotorClient
+
+
+@pytest.fixture(scope='session')
+def event_loop():
+    policy = asyncio.get_event_loop_policy()
+    loop = policy.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope='session')
+def client():
+    return AsyncIOMotorClient('mongodb://localhost:27017')

--- a/tests/integration/repositories/mongodb_auction_repository_test.py
+++ b/tests/integration/repositories/mongodb_auction_repository_test.py
@@ -1,0 +1,40 @@
+from uuid import uuid4
+
+import pytest
+from motor.motor_asyncio import AsyncIOMotorClient
+
+from src.adapters.repositories.auction_repository.mongodb_repository import (
+    MongoAuctionRepository,
+)
+from tests.utils import create_auction, create_bid
+
+
+@pytest.fixture
+async def auction_repository(client: AsyncIOMotorClient):  # type: ignore
+    repo = MongoAuctionRepository(client)
+    yield repo
+    await repo.collection.drop()
+
+
+async def test_get_by_id_success(auction_repository: MongoAuctionRepository):
+    auction = create_auction()
+    await auction_repository.add(auction)
+    assert await auction_repository.get(id=auction.id) == auction
+
+
+async def test_get_by_id_not_found(auction_repository: MongoAuctionRepository):
+    assert await auction_repository.get(id=uuid4()) is None
+
+
+async def test_add_bid_success(auction_repository: MongoAuctionRepository):
+    auction = create_auction()
+    await auction_repository.add(auction)
+    bid = create_bid(auction_id=auction.id)
+    assert await auction_repository.add_bid(bid) is True
+
+
+async def test_add_bid_auction_not_found(
+    auction_repository: MongoAuctionRepository,
+):
+    bid = create_bid(auction_id=uuid4())
+    assert await auction_repository.add_bid(bid) is False


### PR DESCRIPTION
### Description

This PR implements the `mongodb_repository` and adds the engine dependency 3.5.1 to the `pyproject.toml` file.

### Commits

- `feat: add mongodb_repository implementation`
- `test: add unit tests for mongodb_repository`
- `fix: fix bug in MongoDB connection`
- `feat: add engine dependency 3.5.1`

### Changes

- Implementation of the MongoDB repository.
- Addition of unit tests for the repository.
- Bug fixes in the MongoDB connection.
- Update of the `pyproject.toml` file to include the engine dependency 3.5.1.
- Update of the GitHub Actions workflow (`python-tests.yml`) to include the MongoDB service.

### How to Test

1. Run `poetry install` to install the dependencies.
2. Run `poetry run task test` to execute the tests.